### PR TITLE
Fix overlay sound button not responding

### DIFF
--- a/public/overlay.html
+++ b/public/overlay.html
@@ -345,14 +345,39 @@
         function unlockAudio() {
             if (audioUnlocked) return;
 
-            // Leeres Audio abspielen um Browser zu entsperren
-            const audio = new Audio();
+            // Create a very short silent audio to unlock browser autoplay policy
+            const silentMp3 = 'data:audio/mp3;base64,SUQzBAAAAAABEVRYWFgAAAAtAAADY29tbWVudABCaWdTb3VuZEJhbmsuY29tIC8gTGFTb25vdGhlcXVlLm9yZwBURU5DAAAAHQAAA1N3aXRjaCBQbHVzIMKpIE5DSCBTb2Z0d2FyZQBUSVQyAAAABgAAAzIyMzUAVFNTRQAAAA8AAANMYXZmNTcuODMuMTAwAAAAAAAAAAAAAAD/80DEAAAAA0gAAAAATEFNRTMuMTAwVVVVVVVVVVVVVUxBTUUzLjEwMFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVf/zQsRbAAADSAAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVf/zQMSkAAADSAAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV';
+
+            const audio = new Audio(silentMp3);
+            audio.volume = 0.01; // Very low volume
+
             audio.play().then(() => {
                 audioUnlocked = true;
-                document.getElementById('audio-unlock').classList.add('hidden');
+                const button = document.getElementById('audio-unlock');
+
+                // Show success feedback
+                button.innerHTML = '<span>✅</span><span>Audio aktiviert!</span>';
+                button.style.background = 'linear-gradient(135deg, #10b981 0%, #059669 100%)';
+
                 console.log('✅ Audio unlocked!');
+
+                // Hide button after 1 second
+                setTimeout(() => {
+                    button.classList.add('hidden');
+                }, 1000);
             }).catch(err => {
                 console.warn('⚠️ Audio unlock failed:', err);
+
+                // Show error feedback
+                const button = document.getElementById('audio-unlock');
+                button.innerHTML = '<span>❌</span><span>Fehler! Bitte erneut versuchen</span>';
+                button.style.background = 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)';
+
+                // Reset button after 2 seconds
+                setTimeout(() => {
+                    button.innerHTML = '<span>🔊</span><span>Audio aktivieren (Click here)</span>';
+                    button.style.background = 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
+                }, 2000);
             });
         }
 


### PR DESCRIPTION
The audio unlock button was not working because it tried to play an empty Audio element without a source. This caused the browser's autoplay policy unlock to fail.

Changes:
- Use a silent MP3 data URL instead of empty Audio element
- Add visual feedback: green background for success, red for errors
- Button automatically hides after 1 second on success
- Button resets after 2 seconds on error
- Improved user experience with clear status messages

Fixes the issue where clicking the sound button showed no GUI update or browser prompt.