### PR TITLE
Fix syntax error in database module

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -170,15 +170,6 @@ class DatabaseManager {
         const stmt = this.db.prepare(`
             INSERT OR IGNORE INTO hud_elements (element_id, enabled, position_x, position_y, position_unit, width, height, anchor)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            { element_id: 'alert', enabled: 1, position_x: 50, position_y: 50, position_unit: '%', anchor: 'center' },
-            { element_id: 'event-feed', enabled: 1, position_x: 30, position_y: 120, position_unit: 'px', anchor: 'bottom-left' },
-            { element_id: 'chat', enabled: 1, position_x: 30, position_y: 30, position_unit: 'px', anchor: 'bottom-right' },
-            { element_id: 'goal', enabled: 1, position_x: 50, position_y: 30, position_unit: '%', anchor: 'top-center' }
-        ];
-
-        const stmt = this.db.prepare(`
-            INSERT OR IGNORE INTO hud_elements (element_id, enabled, position_x, position_y, position_unit, anchor)
-            VALUES (?, ?, ?, ?, ?, ?)
         `);
 
         for (const element of defaultElements) {
@@ -472,8 +463,6 @@ class DatabaseManager {
         const stmt = this.db.prepare(`
             INSERT INTO hud_elements (element_id, enabled, position_x, position_y, position_unit, width, height, anchor, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-            INSERT INTO hud_elements (element_id, enabled, position_x, position_y, position_unit, anchor, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             ON CONFLICT(element_id) DO UPDATE SET
                 enabled = excluded.enabled,
                 position_x = excluded.position_x,


### PR DESCRIPTION
Fixed two critical syntax errors in modules/database.js:
1. Removed malformed SQL statement with JavaScript objects mixed into SQL string in initializeDefaultHudElements() (lines 170-178)
2. Fixed duplicate INSERT statement in setHudElement() function (lines 472-486)

Both functions now have clean, properly formatted SQL prepared statements with correct placeholder syntax.

This resolves the "SyntaxError: missing ) after argument list" error that prevented the server from starting.