### PR TITLE
Füge Animation-Unterstützung für Geschenke im Soundboard hinzu

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -82,6 +82,8 @@ class DatabaseManager {
                 label TEXT NOT NULL,
                 mp3_url TEXT NOT NULL,
                 volume REAL DEFAULT 1.0,
+                animation_url TEXT,
+                animation_type TEXT DEFAULT 'none',
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         `);

--- a/public/overlay.html
+++ b/public/overlay.html
@@ -228,6 +228,29 @@
             color: #e5e7eb;
         }
 
+        /* ========== GIFT ANIMATIONS ========== */
+        @keyframes giftAnimIn {
+            from {
+                opacity: 0;
+                transform: translate(-50%, -50%) scale(0.5);
+            }
+            to {
+                opacity: 1;
+                transform: translate(-50%, -50%) scale(1);
+            }
+        }
+
+        @keyframes giftAnimOut {
+            from {
+                opacity: 1;
+                transform: translate(-50%, -50%) scale(1);
+            }
+            to {
+                opacity: 0;
+                transform: translate(-50%, -50%) scale(0.8);
+            }
+        }
+
         /* ========== GOAL BAR ========== */
         #goal-container {
             position: absolute;
@@ -537,6 +560,11 @@
             updateGoal(stats.totalCoins);
         });
 
+        // Gift Animation anzeigen
+        socket.on('gift:animation', (data) => {
+            showGiftAnimation(data);
+        });
+
         // ========== ALERT FUNCTIONS ==========
         function showAlert(data) {
             const container = document.getElementById('alert-container');
@@ -777,6 +805,78 @@
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        // ========== GIFT ANIMATIONS ==========
+        function showGiftAnimation(data) {
+            console.log('🎬 Showing gift animation:', data);
+
+            // Erstelle Animation-Container
+            const container = document.createElement('div');
+            container.id = 'gift-animation-' + Date.now();
+            container.style.cssText = `
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: 200;
+                animation: giftAnimIn 0.5s ease-out;
+            `;
+
+            let content = '';
+            const animationType = data.type || 'none';
+            const animationUrl = data.url || '';
+
+            if (animationType === 'image' || animationType === 'gif') {
+                content = `
+                    <div style="text-align: center;">
+                        <img src="${animationUrl}"
+                             style="max-width: 600px; max-height: 600px; border-radius: 20px; box-shadow: 0 20px 60px rgba(0,0,0,0.5);"
+                             onerror="this.style.display='none'" />
+                        <div style="margin-top: 20px; color: white; font-size: 28px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.8);">
+                            ${escapeHtml(data.username)} sent ${escapeHtml(data.giftName)}!
+                        </div>
+                    </div>
+                `;
+            } else if (animationType === 'video') {
+                content = `
+                    <div style="text-align: center;">
+                        <video autoplay muted
+                               style="max-width: 600px; max-height: 600px; border-radius: 20px; box-shadow: 0 20px 60px rgba(0,0,0,0.5);"
+                               onended="this.parentElement.parentElement.remove()">
+                            <source src="${animationUrl}" type="video/mp4">
+                        </video>
+                        <div style="margin-top: 20px; color: white; font-size: 28px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.8);">
+                            ${escapeHtml(data.username)} sent ${escapeHtml(data.giftName)}!
+                        </div>
+                    </div>
+                `;
+            } else {
+                // Fallback: Show gift image from TikTok
+                if (data.giftImage) {
+                    content = `
+                        <div style="text-align: center;">
+                            <img src="${data.giftImage}"
+                                 style="max-width: 400px; max-height: 400px; border-radius: 20px; box-shadow: 0 20px 60px rgba(0,0,0,0.5);"
+                                 onerror="this.style.display='none'" />
+                            <div style="margin-top: 20px; color: white; font-size: 28px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.8);">
+                                ${escapeHtml(data.username)} sent ${escapeHtml(data.giftName)}!
+                            </div>
+                        </div>
+                    `;
+                }
+            }
+
+            if (content) {
+                container.innerHTML = content;
+                document.body.appendChild(container);
+
+                // Animation ausblenden und entfernen
+                setTimeout(() => {
+                    container.style.animation = 'giftAnimOut 0.5s ease-in';
+                    setTimeout(() => container.remove(), 500);
+                }, 4000); // 4 Sekunden anzeigen
+            }
         }
 
         // ========== GOAL BAR ==========

--- a/public/soundboard.html
+++ b/public/soundboard.html
@@ -534,7 +534,9 @@
             assignments[s.giftId] = {
               mp3_url: s.mp3Url || '',
               label: s.label || '',
-              volume: s.volume ?? 1.0
+              volume: s.volume ?? 1.0,
+              animation_url: s.animationUrl || '',
+              animation_type: s.animationType || 'none'
             };
           });
         }
@@ -574,6 +576,8 @@
     function giftRowTemplate(g) {
       const assigned = assignments[g.id] || {};
       const vol = assigned.volume ?? 1.0;
+      const animType = assigned.animation_type || 'none';
+      const animUrl = assigned.animation_url || '';
       const safeName = (g.name || '').replace(/"/g,'&quot;');
       const rowClass = `gift-row flex flex-col gap-2 border border-slate-800 rounded-xl p-3${assigned.mp3_url ? ' assigned' : ''}`;
 
@@ -601,6 +605,18 @@
                   onclick="openPicker('gift:${g.id}')">Picker</button>
           <button class="rounded-lg bg-rose-700/80 hover:bg-rose-600 px-3 py-1.5"
                   onclick="clearGift(${g.id})">✕</button>
+        </div>
+        <div class="flex items-center gap-2 border-t border-slate-700/50 pt-2">
+          <span class="text-xs text-slate-400 flex-shrink-0">🎬 Animation:</span>
+          <select id="anim_type_${g.id}" class="rounded-lg bg-slate-800 border border-slate-700 px-2 py-1 text-sm flex-shrink-0" onchange="updateAssignment(${g.id}, 'animation_type', this.value)">
+            <option value="none" ${animType === 'none' ? 'selected' : ''}>Keine</option>
+            <option value="image" ${animType === 'image' ? 'selected' : ''}>Bild</option>
+            <option value="gif" ${animType === 'gif' ? 'selected' : ''}>GIF</option>
+            <option value="video" ${animType === 'video' ? 'selected' : ''}>Video</option>
+          </select>
+          <input id="anim_url_${g.id}" value="${animUrl}" placeholder="Animation-URL (optional)"
+                 class="flex-1 rounded-lg bg-slate-800 border border-slate-700 px-2 py-1 text-sm"
+                 oninput="updateAssignment(${g.id}, 'animation_url', this.value.trim())" />
         </div>
       </div>`;
     }
@@ -917,7 +933,9 @@
             giftId: Number(id),
             label: data.label || `Gift ${id}`,
             mp3Url: data.mp3_url,
-            volume: data.volume ?? 1.0
+            volume: data.volume ?? 1.0,
+            animationUrl: data.animation_url || null,
+            animationType: data.animation_type || 'none'
           }));
 
         for (const gift of gifts) {
@@ -1488,7 +1506,9 @@
           giftId: Number(id),
           label: data.label || `Gift ${id}`,
           mp3Url: data.mp3_url,
-          volume: data.volume ?? 1.0
+          volume: data.volume ?? 1.0,
+          animationUrl: data.animation_url || null,
+          animationType: data.animation_type || 'none'
         }));
 
       for (const gift of gifts) {
@@ -1592,7 +1612,9 @@
               assignments[gift.giftId] = {
                 mp3_url: gift.mp3Url || '',
                 label: gift.label || '',
-                volume: gift.volume ?? 1.0
+                volume: gift.volume ?? 1.0,
+                animation_url: gift.animationUrl || '',
+                animation_type: gift.animationType || 'none'
               };
             }
           }

--- a/server.js
+++ b/server.js
@@ -551,14 +551,21 @@ app.get('/api/soundboard/gifts', (req, res) => {
 });
 
 app.post('/api/soundboard/gifts', (req, res) => {
-    const { giftId, label, mp3Url, volume } = req.body;
+    const { giftId, label, mp3Url, volume, animationUrl, animationType } = req.body;
 
     if (!giftId || !label || !mp3Url) {
         return res.status(400).json({ success: false, error: 'giftId, label and mp3Url are required' });
     }
 
     try {
-        const id = soundboard.setGiftSound(giftId, label, mp3Url, volume || 1.0);
+        const id = soundboard.setGiftSound(
+            giftId,
+            label,
+            mp3Url,
+            volume || 1.0,
+            animationUrl || null,
+            animationType || 'none'
+        );
         res.json({ success: true, id });
     } catch (error) {
         console.error('Error setting gift sound:', error);


### PR DESCRIPTION
Erweitert das Soundboard-System um die Möglichkeit, für jedes Geschenk nicht nur Sounds, sondern auch visuelle Animationen (Bilder, GIFs, Videos) zu konfigurieren. Die verfügbaren Geschenke aus dem TikTok-Katalog werden nun mit vollständiger Animation-Auswahl angezeigt.

Änderungen:
- Datenbank: Neue Felder animation_url und animation_type in gift_sounds
- Soundboard-Modul: Unterstützung für Gift-Animationen
- Server-API: Erweiterte /api/soundboard/gifts für Animation-Daten
- Soundboard-UI: Dropdown für Animations-Typ + URL-Eingabefeld pro Geschenk
- Overlay: Dynamische Anzeige von Gift-Animationen (image/gif/video)

Die Geschenke-Liste zeigt nun:
✅ Verfügbare Geschenke aus dem Katalog mit Icons/Bildern ✅ Sound-Auswahl mit Lautstärke
✅ Animation-Typ Auswahl (Keine, Bild, GIF, Video)
✅ Animation-URL Eingabe