### PR TITLE
Fix Gift-Event-Display: Behebe null-Werte für Geschenknamen und Coins

### DIFF
--- a/modules/tiktok.js
+++ b/modules/tiktok.js
@@ -347,6 +347,18 @@ class TikTokConnector extends EventEmitter {
             // Extrahiere Gift-Daten
             const giftData = this.extractGiftData(data);
 
+            // Wenn kein Gift-Name vorhanden, versuche aus Katalog zu laden
+            if (!giftData.giftName && giftData.giftId) {
+                const catalogGift = this.db.getGift(giftData.giftId);
+                if (catalogGift) {
+                    giftData.giftName = catalogGift.name;
+                    // Wenn diamondCount nicht verfügbar, nutze Katalog-Wert
+                    if (!giftData.diamondCount && catalogGift.diamond_count) {
+                        giftData.diamondCount = catalogGift.diamond_count;
+                    }
+                }
+            }
+
             // Robuste Coins-Berechnung: diamond_count * 2 * repeat_count
             // (≈2 Coins pro Diamond ist die Standard-Konvertierung)
             const repeatCount = giftData.repeatCount;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -329,7 +329,8 @@ function addEventToLog(type, data) {
             break;
         case 'gift':
             typeIcon = '🎁 Gift';
-            details = `${data.giftName} x${data.repeatCount} (${data.coins} coins)`;
+            const giftName = data.giftName || (data.giftId ? `Gift #${data.giftId}` : 'Unknown Gift');
+            details = `${giftName} x${data.repeatCount} (${data.coins} coins)`;
             break;
         case 'follow':
             typeIcon = '⭐ Follow';


### PR DESCRIPTION
Änderungen:
- Backend (tiktok.js): Gift-Namen werden jetzt aus der Katalog-Datenbank nachgeschlagen, wenn sie im Event fehlen
- Backend (tiktok.js): Diamond-Counts werden ebenfalls aus dem Katalog übernommen falls nicht vorhanden
- Frontend (dashboard.js): Fallback-Anzeige für fehlende Gift-Namen ("Gift #ID" oder "Unknown Gift")

Behebt das Problem dass Geschenke als "null x5 (0 coins)" im Live-Event-Log angezeigt wurden.