### PR TITLE
Fix auto-update function for ZIP installations

### DIFF
--- a/public/js/update-checker.js
+++ b/public/js/update-checker.js
@@ -171,29 +171,36 @@ class UpdateUI {
             if (data.success) {
                 const instructions = data.instructions;
 
+                const methodTitle = instructions.method === 'git' ?
+                    'Update via Git' : 'Update via ZIP-Download';
+
                 const modal = document.createElement('div');
                 modal.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 overflow-y-auto';
                 modal.innerHTML = `
                     <div class="bg-gray-800 rounded-lg p-8 max-w-2xl my-8">
-                        <h3 class="text-2xl font-bold mb-4">📖 Manuelle Update-Anleitung</h3>
+                        <h3 class="text-2xl font-bold mb-4">📖 ${this.escapeHtml(methodTitle)}</h3>
 
                         <div class="mb-6">
-                            <h4 class="text-lg font-semibold mb-2">Methode 1: Git</h4>
-                            <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300">
+                            <p class="text-gray-300 mb-4">
+                                ${instructions.method === 'git'
+                                    ? 'Dein Projekt ist ein Git-Repository. Folge diesen Schritten für ein automatisches Update:'
+                                    : 'Dein Projekt wurde als ZIP-Datei installiert. Du kannst dennoch automatisch updaten!'}
+                            </p>
+                            <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300 bg-gray-900 p-4 rounded">
                                 ${instructions.steps.map(step => `<li>${this.escapeHtml(step)}</li>`).join('')}
                             </ol>
                         </div>
 
-                        <div class="mb-6">
-                            <h4 class="text-lg font-semibold mb-2">Methode 2: Download</h4>
-                            <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300">
-                                ${instructions.alternative.steps.map(step => `<li>${this.escapeHtml(step)}</li>`).join('')}
-                            </ol>
+                        <div class="bg-blue-900 bg-opacity-30 border border-blue-500 rounded p-4 mb-6">
+                            <p class="text-sm text-blue-200">
+                                <strong>💡 Tipp:</strong> Das automatische Update funktioniert sowohl für Git- als auch für ZIP-Installationen!
+                                Klicke einfach auf "Update installieren" im Banner.
+                            </p>
                         </div>
 
                         <div class="flex gap-2">
                             <a href="${this.currentUpdateInfo.releaseUrl}" target="_blank" class="bg-blue-600 px-6 py-2 rounded hover:bg-blue-700 flex-1 text-center">
-                                🌐 Zu GitHub
+                                🌐 Zu GitHub Release
                             </a>
                             <button class="bg-gray-600 px-6 py-2 rounded hover:bg-gray-700" onclick="this.parentElement.parentElement.parentElement.remove()">
                                 Schließen

--- a/server.js
+++ b/server.js
@@ -269,7 +269,7 @@ app.get('/api/update/current', apiLimiter, (req, res) => {
 });
 
 /**
- * POST /api/update/download - Lädt das Update herunter (git pull)
+ * POST /api/update/download - Führt Update durch (Git Pull oder ZIP Download)
  */
 app.post('/api/update/download', authLimiter, async (req, res) => {
     try {


### PR DESCRIPTION
- Fixed zip-lib API usage (was using wrong method)
- Added proper error handling and cleanup for ZIP updates
- Improved logging for better debugging
- Fixed frontend bug with manual update instructions
- Updated API comment to reflect both Git and ZIP support
- ZIP downloads now work for users who installed via GitHub ZIP

The auto-update feature now works for both:
- Git repository installations (git pull)
- ZIP file installations (automatic download & extraction)