### PR TITLE
Fix: TTS Audio-Ausgabe - Socket Event Name und Plugin ID Mismatch beh…

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -217,7 +217,7 @@ function initializeSocketListeners() {
 
     // ========== AUDIO PLAYBACK (Dashboard) ==========
     // TTS Playback im Dashboard
-    socket.on('tts-v2:play', (data) => {
+    socket.on('tts:play', (data) => {
         playDashboardTTS(data);
     });
 

--- a/server.js
+++ b/server.js
@@ -1653,11 +1653,11 @@ const PORT = process.env.PORT || 3000;
                 logger.info('✅ OSC-Bridge injected into Flows');
             }
 
-            // TTS Core V2 Plugin Injektion
-            const ttsPlugin = pluginLoader.getPluginInstance('tts_core_v2');
+            // TTS Plugin Injektion
+            const ttsPlugin = pluginLoader.getPluginInstance('tts');
             if (ttsPlugin) {
                 flows.ttsEngine = ttsPlugin;
-                logger.info('✅ TTS Core V2 injected into Flows');
+                logger.info('✅ TTS injected into Flows');
             }
         } else {
             logger.info('ℹ️  No plugins found in /plugins directory');


### PR DESCRIPTION
…oben

Behebung von zwei kritischen Bugs, die TTS Audio-Playback verhinderten:

1. Socket.IO Event Name Mismatch:
   - Server emittierte 'tts:play' Event
   - Client hörte auf 'tts-v2:play' Event
   - Fix: Client Event-Listener auf 'tts:play' korrigiert
   - Datei: public/js/dashboard.js:220

2. Plugin ID Mismatch (Flow-Integration):
   - Server suchte nach Plugin ID 'tts_core_v2'
   - Tatsächliche Plugin ID ist 'tts'
   - Fix: Plugin Lookup auf korrekte ID 'tts' angepasst
   - Datei: server.js:1657

Diese Änderungen stellen die vollständige TTS Audio-Funktionalität wieder her. Audio-Daten werden nun korrekt vom Server zum Client übertragen und abgespielt.