### PR TITLE
Fix gift-milestone plugin: Remove duplicate code

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -1025,12 +1025,6 @@ class DatabaseManager {
             VALUES (1, 0, ?)
         `);
         statsStmt.run(defaultConfig.threshold);
-        // Initialize stats
-        const statsInitStmt = this.db.prepare(`
-            INSERT OR IGNORE INTO milestone_stats (id, cumulative_coins, current_milestone)
-            VALUES (1, 0, 0)
-        `);
-        statsInitStmt.run();
     }
 
     /**

--- a/plugins/gift-milestone/ui.html
+++ b/plugins/gift-milestone/ui.html
@@ -568,15 +568,6 @@
             document.getElementById('audioVolume').value = config.audio_volume || 80;
             document.getElementById('animationDuration').value = config.animation_duration || 0;
             document.getElementById('sessionReset').checked = config.session_reset || false;
-            document.getElementById('enableToggle').checked = config.enabled;
-            document.getElementById('statusText').textContent = config.enabled ? 'Aktiviert' : 'Deaktiviert';
-            document.getElementById('threshold').value = config.threshold;
-            document.getElementById('incrementStep').value = config.increment_step;
-            document.getElementById('mode').value = config.mode;
-            document.getElementById('playbackMode').value = config.playback_mode;
-            document.getElementById('audioVolume').value = config.audio_volume;
-            document.getElementById('animationDuration').value = config.animation_duration;
-            document.getElementById('sessionReset').checked = config.session_reset;
 
             // Update file previews
             updateFilePreview('gif', config.animation_gif_path);
@@ -594,9 +585,6 @@
             const currentCoins = stats.cumulative_coins || 0;
             const nextMilestone = stats.current_milestone || config.threshold || 1000;
             const progress = nextMilestone > 0 ? (currentCoins / nextMilestone) * 100 : 0;
-            const currentCoins = stats.cumulative_coins || 0;
-            const nextMilestone = stats.current_milestone || config.threshold;
-            const progress = (currentCoins / nextMilestone) * 100;
 
             document.getElementById('currentCoins').textContent = currentCoins.toLocaleString();
             document.getElementById('nextMilestone').textContent = nextMilestone.toLocaleString();


### PR DESCRIPTION
Fixes found in code review:
- ui.html: Remove duplicate form field assignments in populateForm()
- ui.html: Remove duplicate variable declarations in updateStatsDisplay()
- database.js: Remove duplicate stats initialization in initializeMilestoneDefaults()

These duplications caused redundant code execution and potential inconsistencies.