### PR TITLE
fix: Plugin activation state not reflected in GUI

### DIFF
--- a/routes/plugin-routes.js
+++ b/routes/plugin-routes.js
@@ -70,7 +70,7 @@ function setupPluginRoutes(app, pluginLoader, apiLimiter, uploadLimiter, logger)
                         const exists = allPlugins.find(p => p.id === manifest.id);
 
                         if (!exists) {
-                            // Plugin ist nicht geladen (disabled)
+                            // Plugin ist nicht geladen - Status aus State-Datei lesen
                             const state = pluginLoader.state[manifest.id] || {};
                             allPlugins.push({
                                 id: manifest.id,
@@ -79,7 +79,7 @@ function setupPluginRoutes(app, pluginLoader, apiLimiter, uploadLimiter, logger)
                                 version: manifest.version,
                                 author: manifest.author,
                                 type: manifest.type,
-                                enabled: false,
+                                enabled: state.enabled === true,
                                 loadedAt: null
                             });
                         }


### PR DESCRIPTION
Fixed critical bug where plugins showed as inactive in GUI despite being enabled in the plugin manager. The API was hardcoding enabled: false for non-loaded plugins instead of reading the actual state from plugins_state.json.

Changes:
- routes/plugin-routes.js:82: Changed from hardcoded false to state.enabled === true
- This ensures the frontend receives the correct enabled state from persistent storage

Fixes issue where clicking "Aktivieren" didn't make plugin appear active in GUI.